### PR TITLE
Update repeater_list.md

### DIFF
--- a/docs/meshcore/repeater_list.md
+++ b/docs/meshcore/repeater_list.md
@@ -1,3 +1,10 @@
+---
+title: NSW Meshcore Repeater List
+---
+
+As of October 2025, Meshcore identifies repeaters and roomservers using the first two bytes of the node's key prefix. If two repeater nodes share the same key prefix, it may cause the node path to not display correctly and cause issues when pinging a zero-hop node. As a result, a list of repeaters and their public keys can be found here so that when meshers create a new node they can confirm whether their node key may need to be updated.
+
+
 | public_key_prefix | name | public_key |
 | --- | --- | --- |
 | 01 | VK2MR Roof (ebyte) | 012905f6fe2b496e89400b5c698e1c214602d4931dc1b5ef1145e7feeaff57ab |


### PR DESCRIPTION
Added a title and short explanation of why a list of repeaters and prefixes is handy. Think the missing title was causing the doc not to display properly in the nswmesh.au main page.